### PR TITLE
Add compatibility fixes for django 1.8

### DIFF
--- a/django_options/compat.py
+++ b/django_options/compat.py
@@ -1,0 +1,4 @@
+try:
+    from django.contrib.admin.helpers import normalize_fieldsets
+except ImportError:
+    normalize_fieldsets = lambda x: x

--- a/django_options/formset.py
+++ b/django_options/formset.py
@@ -1,10 +1,14 @@
 from django import forms
 from django.conf import settings
-from django.contrib.admin.helpers import normalize_fieldsets, AdminReadonlyField, AdminField
+from django.contrib.admin.helpers import AdminReadonlyField, AdminField
 from django.contrib.admin.templatetags.admin_static import static
 from django.utils.safestring import mark_safe
 
+from .compat import normalize_fieldsets
+
+
 class AdminForm(object):
+
     def __init__(self, form, fieldsets, readonly_fields=None):
         self.form, self.fieldsets = form, normalize_fieldsets(fieldsets)
         if readonly_fields is None:

--- a/django_options/models.py
+++ b/django_options/models.py
@@ -42,3 +42,4 @@ class Option(models.Model):
         unique_together = ('site', 'key',)
         verbose_name = _('Option')
         verbose_name_plural = _('Options')
+        app_label = 'django_options'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 django
 django-picklefield
+django-faker

--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 import sys
 
+import django
 from django.conf import settings
+
 
 def configure():
 
@@ -10,19 +12,25 @@ def configure():
             'default': {
                 'ENGINE': 'django.db.backends.sqlite3',
                 'NAME': ':memory:',
-                }
+            }
         },
         INSTALLED_APPS=(
             'django.contrib.sites',
             'django_faker',
             'django_options',
             'picklefield',
-            'django_extensions',
-            ),
+            # 'django_extensions',
+        ),
         SITE_ID=1,
     )
 
-if not settings.configured: configure()
+if not settings.configured:
+    configure()
+
+try:
+    django.setup()
+except Exception:
+    pass
 
 
 def runtests(app_labels=None, verbosity=1):
@@ -34,7 +42,6 @@ def runtests(app_labels=None, verbosity=1):
 
 
 if __name__ == '__main__':
-    import sys
     verbosity = 1
     args = sys.argv[1:]
     idx = args.index('-v') if '-v' in args else -1
@@ -43,5 +50,3 @@ if __name__ == '__main__':
         verbosity = int(args.pop(idx)) if len(args) > idx else 2
 
     runtests(args, verbosity=verbosity)
-
-


### PR DESCRIPTION
- fixes warning: `app_label` is required 
- add compatibility for `normalize_fieldsets` (removed in django 1.7)
- use new replace `get_queryset` with a fallback to `get_query_set`
- fix test runner for django >=1.7

[1] https://github.com/django/django/commit/65faa84de3fd3f42e938301574cccdec1578657d
